### PR TITLE
[Bug] Treat commands as case insensitive and ignore trailing whitespace

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,6 +1,7 @@
 import { persistJira } from '~/lib/commands/jira';
 import { getCupcake, getEnhancedCupcake } from '~/lib/commands/cupcake';
 import { lunchDeals } from '~/lib/commands/lunch';
+import parseAction from '~/lib/parser';
 
 export { getFlowbotCommands };
 export default handleCommand;
@@ -11,9 +12,8 @@ function handleCommand(event, commands = getFlowbotCommands()) {
         return Promise.resolve();
     }
 
-    let command = event.content.replace(/^\./, '');
-    if (command in commands) {
-        let action = commands[command];
+    let action = parseAction(event.content, commands);
+    if (action) {
         return action(event);
     }
     else {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,10 @@
 export default parseAction;
 
 function parseAction(content, commands) {
-    let command = content.replace(/^\./, '');
+    let command = content
+        .replace(/^\./, '') // strip leading prefix
+        .toLowerCase();     // accept oddly cased commands
+
     if (command in commands) {
         return commands[command];
     }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2,8 +2,9 @@ export default parseAction;
 
 function parseAction(content, commands) {
     let command = content
-        .replace(/^\./, '') // strip leading prefix
-        .toLowerCase();     // accept oddly cased commands
+        .replace(/^\./, '')   // strip leading period prefix
+        .toLowerCase()        // accept oddly cased commands
+        .replace(/\s+$/, ''); // ignore trailing whitespace
 
     if (command in commands) {
         return commands[command];

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,0 +1,11 @@
+export default parseAction;
+
+function parseAction(content, commands) {
+    let command = content.replace(/^\./, '');
+    if (command in commands) {
+        return commands[command];
+    }
+    else {
+        return undefined;
+    }
+}

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import parseAction from '~/lib/parser';
+
+describe('Parsing commands', () => {
+    let content, commands;
+    beforeEach(() => {
+        content = '.name';
+        commands = {
+            name: 'value'
+        };
+    });
+
+    it('should handle exact string matches', () => {
+        expect(parseAction(content, commands)).to.be.truthy;
+    });
+});

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -20,4 +20,10 @@ describe('Parsing commands', () => {
         const assert = parseAction(`.${content}`, commands);
         expect(assert).to.equal(commands[content.toLowerCase()]);
     });
+
+    it('should ignore surrounding whitespace', () => {
+        const content = '.key     ';
+        const assert = parseAction(content, commands);
+        expect(assert).to.equal(commands.key);
+    });
 });

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -2,15 +2,22 @@ import { expect } from 'chai';
 import parseAction from '~/lib/parser';
 
 describe('Parsing commands', () => {
-    let content, commands;
+    let commands;
     beforeEach(() => {
-        content = '.name';
         commands = {
-            name: 'value'
+            key: 'value'
         };
     });
 
-    it('should handle exact string matches', () => {
-        expect(parseAction(content, commands)).to.be.truthy;
+    it('should parse exact string matches', () => {
+        const content = 'key';
+        const assert = parseAction(`.${content}`, commands);
+        expect(assert).to.equal(commands[content]);
+    });
+
+    it('should ignore case during matches', () => {
+        const content = 'KeY';
+        const assert = parseAction(`.${content}`, commands);
+        expect(assert).to.equal(commands[content.toLowerCase()]);
     });
 });


### PR DESCRIPTION
Allow more user variation when entering commands:
- Accept case-insensitivity (.cupCake, .Cupcake, .CuPcAkE, etc.)
- Accept trailing whitespaces (".cupcake ", ".cupcake      ", etc.)